### PR TITLE
Add parseEncodedEAT util

### DIFF
--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./buildEnrollmentUrl";
 export * from "./generatePopup";
 export * from "./handleRedirect";
 export * from "./iframeTransport";
+export * from "./parseEncodedEAT";

--- a/packages/sdk/src/utils/parseEncodedEAT.ts
+++ b/packages/sdk/src/utils/parseEncodedEAT.ts
@@ -1,0 +1,21 @@
+import { splitSignature } from "@ethersproject/bytes";
+import { EAT } from "..";
+
+const parseEncodedEAT = (base64EncodedEAT: string): EAT => {
+  const decodedEAT = JSON.parse(atob(base64EncodedEAT));
+
+  const decodedSignature = decodedEAT?.signature;
+
+  if (!decodedEAT?.signature || !decodedEAT?.expiry) {
+    throw new Error("Error handling response from Violet: EAT decoding failed.");
+  }
+
+  const signature = splitSignature(decodedSignature);
+
+  return {
+    signature,
+    expiry: decodedEAT.expiry,
+  };
+};
+
+export { parseEncodedEAT };


### PR DESCRIPTION
Useful util to improve devX so that developers wont have to manually decode and parse an EAT received in the callback url.